### PR TITLE
LogViewController's tableView rowHeight set UITableViewAutoDimension

### DIFF
--- a/Sources/Logs/LogViewController.swift
+++ b/Sources/Logs/LogViewController.swift
@@ -184,6 +184,8 @@ class LogViewController: UIViewController, UISearchBarDelegate, UITableViewDeleg
         defaultTableView.tableFooterView = UIView()
         defaultTableView.delegate = self
         defaultTableView.dataSource = self
+        defaultTableView.rowHeight = UITableViewAutomaticDimension
+        defaultTableView.estimatedRowHeight = UITableViewAutomaticDimension
         defaultSearchBar.delegate = self
         defaultSearchBar.text = DotzuXSettings.shared.logSearchWordDefault
         defaultSearchBar.isHidden = true
@@ -191,6 +193,8 @@ class LogViewController: UIViewController, UISearchBarDelegate, UITableViewDeleg
         colorTableView.tableFooterView = UIView()
         colorTableView.delegate = self
         colorTableView.dataSource = self
+        colorTableView.rowHeight = UITableViewAutomaticDimension
+        colorTableView.estimatedRowHeight = UITableViewAutomaticDimension
         colorSearchBar.delegate = self
         colorSearchBar.text = DotzuXSettings.shared.logSearchWordColor
         colorSearchBar.isHidden = true


### PR DESCRIPTION
I can not check the log text because the size of table view is not applied to auto layout.
Therefore, we have applied UITableViewAutoDimension at creation time.